### PR TITLE
Refactor project for native macOS desktop experience

### DIFF
--- a/macos-app/electron/main.ts
+++ b/macos-app/electron/main.ts
@@ -1,0 +1,414 @@
+import { app, BrowserWindow, Menu, shell, ipcMain, dialog, nativeTheme } from 'electron';
+import { join } from 'path';
+import { spawn, ChildProcess } from 'child_process';
+import Store from 'electron-store';
+import { autoUpdater } from 'electron-updater';
+
+// Store for app settings
+const store = new Store();
+
+// Global reference to prevent garbage collection
+let mainWindow: BrowserWindow | null = null;
+let n8nProcess: ChildProcess | null = null;
+let n8nPort = 5678;
+
+// macOS-specific settings
+const isMac = process.platform === 'darwin';
+
+// Development mode detection
+const isDev = process.env.NODE_ENV === 'development';
+
+class N8nDesktopApp {
+  private n8nPath: string;
+  private n8nDataPath: string;
+
+  constructor() {
+    this.n8nPath = join(__dirname, '..', '..', 'packages', 'cli', 'bin', 'n8n');
+    this.n8nDataPath = join(app.getPath('userData'), 'n8n-data');
+    
+    this.setupApp();
+  }
+
+  private setupApp(): void {
+    // Handle app events
+    app.whenReady().then(() => this.createWindow());
+    app.on('window-all-closed', () => this.handleAllWindowsClosed());
+    app.on('activate', () => this.handleActivate());
+    app.on('before-quit', () => this.handleBeforeQuit());
+
+    // Setup auto-updater
+    this.setupAutoUpdater();
+
+    // Setup IPC handlers
+    this.setupIpcHandlers();
+
+    // Setup native menu
+    this.setupMenu();
+  }
+
+  private async createWindow(): Promise<void> {
+    // Create the browser window
+    mainWindow = new BrowserWindow({
+      width: 1400,
+      height: 900,
+      minWidth: 1200,
+      minHeight: 800,
+      show: false,
+      titleBarStyle: isMac ? 'hiddenInset' : 'default',
+      trafficLightPosition: { x: 20, y: 20 },
+      webPreferences: {
+        nodeIntegration: false,
+        contextIsolation: true,
+        enableRemoteModule: false,
+        preload: join(__dirname, 'preload.js')
+      },
+      icon: join(__dirname, '..', 'assets', 'icon.png'),
+      backgroundColor: '#1a1a1a'
+    });
+
+    // Load the app
+    if (isDev) {
+      await mainWindow.loadURL('http://localhost:8080');
+      mainWindow.webContents.openDevTools();
+    } else {
+      await mainWindow.loadFile(join(__dirname, '..', '..', 'packages', 'frontend', 'editor-ui', 'dist', 'index.html'));
+    }
+
+    // Show window when ready
+    mainWindow.once('ready-to-show', () => {
+      mainWindow?.show();
+      this.startN8nServer();
+    });
+
+    // Handle window events
+    mainWindow.on('closed', () => {
+      mainWindow = null;
+    });
+
+    // Handle external links
+    mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+      shell.openExternal(url);
+      return { action: 'deny' };
+    });
+  }
+
+  private async startN8nServer(): Promise<void> {
+    try {
+      // Set environment variables for n8n
+      const env = {
+        ...process.env,
+        N8N_USER_FOLDER: this.n8nDataPath,
+        N8N_PORT: n8nPort.toString(),
+        N8N_HOST: 'localhost',
+        N8N_PROTOCOL: 'http',
+        NODE_ENV: 'production',
+        N8N_DISABLE_UI: 'false',
+        N8N_DISABLE_PRODUCTION_MAIN_PROCESS: 'true'
+      };
+
+      // Start n8n process
+      n8nProcess = spawn(this.n8nPath, ['start'], {
+        env,
+        stdio: ['pipe', 'pipe', 'pipe']
+      });
+
+      // Handle n8n process events
+      n8nProcess.on('error', (error) => {
+        console.error('Failed to start n8n:', error);
+        this.showErrorDialog('Failed to start n8n server', error.message);
+      });
+
+      n8nProcess.on('exit', (code) => {
+        console.log(`n8n process exited with code ${code}`);
+        if (code !== 0 && mainWindow) {
+          this.showErrorDialog('n8n server stopped unexpectedly', `Exit code: ${code}`);
+        }
+      });
+
+      // Log n8n output
+      n8nProcess.stdout?.on('data', (data) => {
+        console.log('n8n stdout:', data.toString());
+      });
+
+      n8nProcess.stderr?.on('data', (data) => {
+        console.error('n8n stderr:', data.toString());
+      });
+
+    } catch (error) {
+      console.error('Error starting n8n:', error);
+      this.showErrorDialog('Failed to start n8n', error instanceof Error ? error.message : 'Unknown error');
+    }
+  }
+
+  private setupAutoUpdater(): void {
+    autoUpdater.autoDownload = false;
+    autoUpdater.autoInstallOnAppQuit = true;
+
+    autoUpdater.on('checking-for-update', () => {
+      console.log('Checking for updates...');
+    });
+
+    autoUpdater.on('update-available', (info) => {
+      console.log('Update available:', info);
+      dialog.showMessageBox(mainWindow!, {
+        type: 'info',
+        title: 'Update Available',
+        message: 'A new version of n8n Desktop is available.',
+        detail: `Version ${info.version} is ready to download.`,
+        buttons: ['Download', 'Later'],
+        defaultId: 0
+      }).then((result) => {
+        if (result.response === 0) {
+          autoUpdater.downloadUpdate();
+        }
+      });
+    });
+
+    autoUpdater.on('update-downloaded', () => {
+      dialog.showMessageBox(mainWindow!, {
+        type: 'info',
+        title: 'Update Ready',
+        message: 'Update downloaded successfully.',
+        detail: 'The app will restart to install the update.',
+        buttons: ['Restart Now', 'Later'],
+        defaultId: 0
+      }).then((result) => {
+        if (result.response === 0) {
+          autoUpdater.quitAndInstall();
+        }
+      });
+    });
+
+    autoUpdater.on('error', (error) => {
+      console.error('Auto-updater error:', error);
+    });
+
+    // Check for updates on startup
+    setTimeout(() => {
+      autoUpdater.checkForUpdates();
+    }, 5000);
+  }
+
+  private setupIpcHandlers(): void {
+    // Handle theme changes
+    ipcMain.handle('get-theme', () => {
+      return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+    });
+
+    ipcMain.handle('set-theme', (_, theme: 'light' | 'dark' | 'system') => {
+      nativeTheme.themeSource = theme;
+      store.set('theme', theme);
+    });
+
+    // Handle n8n server status
+    ipcMain.handle('get-n8n-status', () => {
+      return {
+        running: n8nProcess !== null && !n8nProcess.killed,
+        port: n8nPort,
+        url: `http://localhost:${n8nPort}`
+      };
+    });
+
+    // Handle app settings
+    ipcMain.handle('get-settings', () => {
+      return store.store;
+    });
+
+    ipcMain.handle('set-setting', (_, key: string, value: any) => {
+      store.set(key, value);
+    });
+  }
+
+  private setupMenu(): void {
+    const template: Electron.MenuItemConstructorOptions[] = [
+      {
+        label: 'n8n Desktop',
+        submenu: [
+          {
+            label: 'About n8n Desktop',
+            role: 'about'
+          },
+          { type: 'separator' },
+          {
+            label: 'Preferences...',
+            accelerator: 'Cmd+,',
+            click: () => {
+              // Open preferences window
+            }
+          },
+          { type: 'separator' },
+          {
+            label: 'Services',
+            role: 'services',
+            submenu: []
+          },
+          { type: 'separator' },
+          {
+            label: 'Hide n8n Desktop',
+            accelerator: 'Cmd+H',
+            role: 'hide'
+          },
+          {
+            label: 'Hide Others',
+            accelerator: 'Cmd+Alt+H',
+            role: 'hideothers'
+          },
+          {
+            label: 'Show All',
+            role: 'unhide'
+          },
+          { type: 'separator' },
+          {
+            label: 'Quit n8n Desktop',
+            accelerator: 'Cmd+Q',
+            click: () => {
+              app.quit();
+            }
+          }
+        ]
+      },
+      {
+        label: 'File',
+        submenu: [
+          {
+            label: 'New Workflow',
+            accelerator: 'Cmd+N',
+            click: () => {
+              mainWindow?.webContents.send('new-workflow');
+            }
+          },
+          {
+            label: 'Open Workflow...',
+            accelerator: 'Cmd+O',
+            click: () => {
+              this.openWorkflowFile();
+            }
+          },
+          { type: 'separator' },
+          {
+            label: 'Close Window',
+            accelerator: 'Cmd+W',
+            role: 'close'
+          }
+        ]
+      },
+      {
+        label: 'Edit',
+        submenu: [
+          { label: 'Undo', accelerator: 'Cmd+Z', role: 'undo' },
+          { label: 'Redo', accelerator: 'Shift+Cmd+Z', role: 'redo' },
+          { type: 'separator' },
+          { label: 'Cut', accelerator: 'Cmd+X', role: 'cut' },
+          { label: 'Copy', accelerator: 'Cmd+C', role: 'copy' },
+          { label: 'Paste', accelerator: 'Cmd+V', role: 'paste' },
+          { label: 'Select All', accelerator: 'Cmd+A', role: 'selectall' }
+        ]
+      },
+      {
+        label: 'View',
+        submenu: [
+          { label: 'Reload', accelerator: 'Cmd+R', role: 'reload' },
+          { label: 'Force Reload', accelerator: 'Cmd+Shift+R', role: 'forceReload' },
+          { label: 'Toggle Developer Tools', accelerator: 'F12', role: 'toggleDevTools' },
+          { type: 'separator' },
+          { label: 'Actual Size', accelerator: 'Cmd+0', role: 'resetZoom' },
+          { label: 'Zoom In', accelerator: 'Cmd+Plus', role: 'zoomIn' },
+          { label: 'Zoom Out', accelerator: 'Cmd+-', role: 'zoomOut' },
+          { type: 'separator' },
+          { label: 'Toggle Full Screen', accelerator: 'Ctrl+Cmd+F', role: 'togglefullscreen' }
+        ]
+      },
+      {
+        label: 'Window',
+        submenu: [
+          { label: 'Minimize', accelerator: 'Cmd+M', role: 'minimize' },
+          { label: 'Close', accelerator: 'Cmd+W', role: 'close' }
+        ]
+      },
+      {
+        label: 'Help',
+        submenu: [
+          {
+            label: 'n8n Documentation',
+            click: () => {
+              shell.openExternal('https://docs.n8n.io');
+            }
+          },
+          {
+            label: 'Community Forum',
+            click: () => {
+              shell.openExternal('https://community.n8n.io');
+            }
+          },
+          { type: 'separator' },
+          {
+            label: 'About n8n',
+            click: () => {
+              shell.openExternal('https://n8n.io');
+            }
+          }
+        ]
+      }
+    ];
+
+    const menu = Menu.buildFromTemplate(template);
+    Menu.setApplicationMenu(menu);
+  }
+
+  private async openWorkflowFile(): Promise<void> {
+    const result = await dialog.showOpenDialog(mainWindow!, {
+      properties: ['openFile'],
+      filters: [
+        { name: 'n8n Workflows', extensions: ['json'] },
+        { name: 'All Files', extensions: ['*'] }
+      ]
+    });
+
+    if (!result.canceled && result.filePaths.length > 0) {
+      mainWindow?.webContents.send('open-workflow-file', result.filePaths[0]);
+    }
+  }
+
+  private showErrorDialog(title: string, message: string): void {
+    if (mainWindow) {
+      dialog.showErrorBox(title, message);
+    }
+  }
+
+  private handleAllWindowsClosed(): void {
+    if (!isMac) {
+      app.quit();
+    }
+  }
+
+  private handleActivate(): void {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      this.createWindow();
+    }
+  }
+
+  private async handleBeforeQuit(): Promise<void> {
+    // Stop n8n process gracefully
+    if (n8nProcess && !n8nProcess.killed) {
+      n8nProcess.kill('SIGTERM');
+      
+      // Wait for process to terminate
+      return new Promise((resolve) => {
+        const timeout = setTimeout(() => {
+          if (n8nProcess && !n8nProcess.killed) {
+            n8nProcess.kill('SIGKILL');
+          }
+          resolve();
+        }, 5000);
+
+        n8nProcess?.on('exit', () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+    }
+  }
+}
+
+// Initialize the app
+new N8nDesktopApp();

--- a/macos-app/electron/tsconfig.json
+++ b/macos-app/electron/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "../dist",
+    "rootDir": "./",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "removeComments": false,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false
+  },
+  "include": [
+    "**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/macos-app/package.json
+++ b/macos-app/package.json
@@ -1,0 +1,85 @@
+{
+  "name": "n8n-desktop",
+  "version": "1.0.0",
+  "description": "Native macOS application for n8n workflow automation",
+  "main": "dist/main.js",
+  "homepage": "./",
+  "scripts": {
+    "dev": "concurrently \"npm run dev:electron\" \"npm run dev:renderer\"",
+    "dev:electron": "tsc -p electron/tsconfig.json && electron .",
+    "dev:renderer": "cd ../packages/frontend/editor-ui && npm run dev",
+    "build": "npm run build:renderer && npm run build:electron",
+    "build:renderer": "cd ../packages/frontend/editor-ui && npm run build",
+    "build:electron": "tsc -p electron/tsconfig.json",
+    "build:mac": "npm run build && electron-builder --mac",
+    "build:mac-universal": "npm run build && electron-builder --mac --universal",
+    "dist": "npm run build && electron-builder",
+    "dist:mac": "npm run build && electron-builder --mac",
+    "postinstall": "electron-builder install-app-deps",
+    "start": "electron .",
+    "pack": "npm run build && electron-builder --dir",
+    "test": "jest"
+  },
+  "build": {
+    "appId": "io.n8n.desktop",
+    "productName": "n8n Desktop",
+    "directories": {
+      "output": "dist-electron"
+    },
+    "files": [
+      "dist/**/*",
+      "node_modules/**/*",
+      "package.json"
+    ],
+    "mac": {
+      "category": "public.app-category.productivity",
+      "target": [
+        {
+          "target": "dmg",
+          "arch": ["arm64", "x64"]
+        },
+        {
+          "target": "zip",
+          "arch": ["arm64", "x64"]
+        }
+      ],
+      "icon": "assets/icon.icns",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "assets/entitlements.mac.plist",
+      "entitlementsInherit": "assets/entitlements.mac.plist",
+      "extendInfo": {
+        "NSAppTransportSecurity": {
+          "NSAllowsArbitraryLoads": true
+        },
+        "LSMinimumSystemVersion": "12.0.0",
+        "NSHighResolutionCapable": true,
+        "NSSupportsAutomaticGraphicsSwitching": true
+      }
+    },
+    "dmg": {
+      "title": "n8n Desktop",
+      "icon": "assets/icon.icns",
+      "background": "assets/dmg-background.png",
+      "window": {
+        "width": 540,
+        "height": 380
+      }
+    }
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "concurrently": "^8.2.0",
+    "electron": "^28.0.0",
+    "electron-builder": "^24.0.0",
+    "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "electron-store": "^8.1.0",
+    "electron-updater": "^6.1.0",
+    "node-fetch": "^3.3.0"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces an Electron-based native macOS desktop application for n8n. The goal is to provide an intuitive, self-contained experience for non-developer users, leveraging macOS ecosystem features and optimizing for Apple Silicon (M3 Pro).

The application bundles the existing n8n Node.js backend and Vue.js frontend within an Electron wrapper. It manages the n8n server as a child process and serves the frontend locally.

**Key changes include:**
-   **`macos-app/electron/main.ts`**: Electron main process code for window management, spawning the n8n server, handling auto-updates, IPC communication, and native macOS menu integration.
-   **`macos-app/package.json`**: Configures the Electron application, including `electron-builder` settings for macOS (universal binaries for ARM64/x64, hardened runtime, entitlements, icon, DMG packaging).
-   **`macos-app/electron/tsconfig.json`**: TypeScript configuration for the Electron main process.

**To test:**
1.  Navigate to the `macos-app` directory.
2.  Run `npm install` to install Electron dependencies.
3.  Run `npm run dev` to start the Electron app in development mode (this will also start the n8n frontend dev server).
4.  Verify the n8n UI loads and the server is running.
5.  Test basic functionalities like creating a workflow, saving, and running it.
6.  Test macOS specific features like menu items (e.g., Quit, Hide, Copy/Paste), and ensure external links open in the default browser.
7.  (Optional) Run `npm run build:mac-universal` to build a universal macOS application and test the packaged app.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

-   [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
    **Remember, the title automatically goes into the changelog.
    Use `(no-changelog)` otherwise.**
-->
-   [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
-   [ ] Tests included. <!--
    A bug is not considered fixed, unless a test is added to prevent it from happening again.
    A feature is not complete without tests.
-->
-   [ ] PR Labeled with `release/backport` (if the PR is an urgent fix that needs to be backported)

---
<a href="https://cursor.com/background-agent?bcId=bc-d4298fdd-5d24-4afb-979c-dfdbbddcb2aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4298fdd-5d24-4afb-979c-dfdbbddcb2aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

